### PR TITLE
Fix GitHub Links

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jlarmstrongiv/annoy-node-prebuild.git"
+    "url": "git+https://github.com/prathameshnetake/annoy-node-prebuild.git"
   },
   "keywords": [
     "annoy",
@@ -35,9 +35,9 @@
   "author": "Prathamesh Netake",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/jlarmstrongiv/annoy-node-prebuild/issues"
+    "url": "https://github.com/prathameshnetake/annoy-node-prebuild/issues"
   },
-  "homepage": "https://github.com/jlarmstrongiv/annoy-node-prebuild#readme",
+  "homepage": "https://github.com/prathameshnetake/annoy-node-prebuild#readme",
   "dependencies": {
     "@types/node": "^15.6.1",
     "bindings": "^1.5.0",


### PR DESCRIPTION
I had to switch the GitHub links in order to test and debug the example releases, switching back to merge to master.  Sorry about that!  Followup to https://github.com/prathameshnetake/annoy-node/pull/4

Thank you!  Looking forward to the next release.